### PR TITLE
Fixing two issues with latest Node JS 

### DIFF
--- a/src/hoard.coffee
+++ b/src/hoard.coffee
@@ -42,7 +42,7 @@ create = (filename, archives, xFilesFactor, cb) ->
         # Using 'buffer_ieee754' from node 0.5.x
         # as no libraries had a working IEEE754 encoder
         buffer = new Buffer(4)
-        require('./buffer_ieee754').writeIEEE754(buffer, 0.5, 0, 'big', 23, 4);
+        require('./buffer_ieee754.js').writeIEEE754(buffer, 0.5, 0, 'big', 23, 4);
         buffer
 
     buffer = Put()

--- a/src/hoard.coffee
+++ b/src/hoard.coffee
@@ -32,7 +32,7 @@ create = (filename, archives, xFilesFactor, cb) ->
     # FIXME: Check that values are correctly formatted
     archives.sort (a, b) -> a[0] - b[0]
 
-    if path.existsSync(filename)
+    if fs.existsSync(filename)
         cb new Error('File ' + filename + ' already exists')
 
     oldest = (a[0] * a[1] for a in archives).sort().reverse()[0]


### PR DESCRIPTION
Hi Carl,

I am interested to use Hoard time series database as a storage for upcoming features I am working on Meshcentral. However I discover two issues, one is related to path.fileExistsSync that has been moved to fs.fileExistsSync and buffer_ieee754 reference (adding .js) extension.

I made this two changes and it seems working well with Node JS 6.10.1. Please merge this so that we can get a working Hoard library.

Regards,


Joko Sastriawan